### PR TITLE
Service を追加した Read 処理と例外をハンドリングする処理の実装

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       MYSQL_USER: user
       MYSQL_PASSWORD: password
     ports:
-      - "3308:3306"
+      - 3307:3306
     volumes:
       - ./sql:/docker-entrypoint-initdb.d
       - my-vol:/var/lib/mysql

--- a/src/main/java/com/example/general/GeneralController.java
+++ b/src/main/java/com/example/general/GeneralController.java
@@ -1,19 +1,37 @@
 package com.example.general;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
+import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 public class GeneralController {
-    private GeneralMapper generalMapper;
+    private final GeneralService generalService;
 
-    public GeneralController(GeneralMapper generalMapper) {
-        this.generalMapper = generalMapper;
-    }
+    public GeneralController(GeneralService generalService) { this.generalService = generalService;}
     @GetMapping("/generals")
-    public List<General> getGenerals() {
-        return generalMapper.findAll();
+    public List<General> findByGenerals(@RequestParam("startsWith") String startsWith) {
+        return generalService.findGeneralsStartingWith(startsWith);
     }
+
+    @GetMapping("/generals/{id}")
+    public General findGeneral(@PathVariable("id") int id) { return generalService.findGeneral(id);}
+
+    @ExceptionHandler(GeneralNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleGeneralNotFoundException(
+        GeneralNotFoundException e, HttpServletRequest request) {
+             Map<String, String> body = Map.of(
+                "timestamp", ZonedDateTime.now().toString(),
+                "status", String.valueOf(HttpStatus.NOT_FOUND.value()),
+                "error", HttpStatus.NOT_FOUND.getReasonPhrase(),
+                "message", e.getMessage(),
+                "path", request.getRequestURI());
+             return new ResponseEntity(body, HttpStatus.NOT_FOUND);
+    }
+
 }

--- a/src/main/java/com/example/general/GeneralMapper.java
+++ b/src/main/java/com/example/general/GeneralMapper.java
@@ -4,9 +4,16 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Select;
 
 import java.util.List;
+import java.util.Optional;
 
 @Mapper
 public interface GeneralMapper {
     @Select("SELECT * FROM generals")
     List<General> findAll();
+
+    @Select("SELECT * FROM generals WHERE name LIKE CONCAT(#{prefix}, '%')")
+    List<General> findByGeneralStartingWith(String prefix);
+
+    @Select("SELECT *FROM generals WHERE id = #{id}")
+    Optional<General> findById(int id);
 }

--- a/src/main/java/com/example/general/GeneralNotFoundException.java
+++ b/src/main/java/com/example/general/GeneralNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.general;
+
+public class GeneralNotFoundException extends RuntimeException {
+    public GeneralNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/general/GeneralService.java
+++ b/src/main/java/com/example/general/GeneralService.java
@@ -1,0 +1,24 @@
+package com.example.general;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class GeneralService {
+    private final GeneralMapper generalMapper;
+
+    public GeneralService(GeneralMapper generalMapper) { this.generalMapper = generalMapper; }
+
+    public List<General> findGeneralsStartingWith(String prefix) { return generalMapper.findByGeneralStartingWith(prefix); }
+
+    public General findGeneral(int id) {
+        Optional<General> general = generalMapper.findById(id);
+        if (general.isPresent()) {
+            return general.get();
+        } else {
+            throw new GeneralNotFoundException("name not found");
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 spring.application.name=general
-spring.datasource.url=jdbc:mysql://localhost:3308/general_database
+spring.datasource.url=jdbc:mysql://localhost:3307/general_database
 spring.datasource.username=user
 spring.datasource.password=password


### PR DESCRIPTION
# 第９回課題


## 概要
第８回課題のコードに Serviceクラスの作成と例外をハンドリングする処理を追加しました。


## 動作確認

MySQL のGenerals テーブルの出力結果
![スクリーンショット 2024-04-30 235641](https://github.com/Rio00o/ASG8th/assets/157946761/a0f3ac97-44f1-4b52-9cf6-17f464e66c14)

generals の id=1 をリクエストした結果
ステータスコード 200 OK
![スクリーンショット 2024-05-01 003304 png,,,](https://github.com/Rio00o/ASG8th/assets/157946761/3f39592b-4825-4e63-bc35-b004bb319434)

generals の id=4 をリクエストした結果（例外処理）
ステータスコード 404 Not Found
![第９回課題１](https://github.com/Rio00o/ASG8th/assets/157946761/30a1349b-5673-4b5e-89cc-4316e39c996a)

generals の "織田" で始まる名前を持つ人物の ID を取得する結果
ステータスコード 200 OK
![スクリーンショット 2024-04-30 233231 png,,](https://github.com/Rio00o/ASG8th/assets/157946761/4358e03e-7de2-412f-98e4-20df23168172)
